### PR TITLE
Update pubspec.yaml path_provider plugin version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   sdk: ">=2.0.0-dev.68.0 <3.0.0"
 
 dependencies:
-  path_provider: ^0.4.1
+  path_provider: ^0.5.0+1
   flutter:
     sdk: flutter
 


### PR DESCRIPTION
The path_provider plugin has a newer version and this can cause conflicts when using with different plugins that use the newer version.