### PR TITLE
Removal of compilation warning

### DIFF
--- a/lib/screenshot.dart
+++ b/lib/screenshot.dart
@@ -42,7 +42,7 @@ class ScreenshotController {
     Duration delay = const Duration(milliseconds: 20),
   }) {
     //Delay is required. See Issue https://github.com/flutter/flutter/issues/22308
-    return new Future.delayed(delay ?? Duration(milliseconds: 20), () async {
+    return new Future.delayed(delay, () async {
       try {
         ui.Image image = await captureAsUiImage(
           delay: Duration.zero,


### PR DESCRIPTION
This PR fixes the following issue:
```
/C:/src/flutter/.pub-cache/hosted/pub.dartlang.org/screenshot-1.2.0/lib/screenshot.dart:45:31: Warning: Operand of null-aware operation '??' has type 'Duration' which excludes null.
 - 'Duration' is from 'dart:core'.
    return new Future.delayed(delay ?? Duration(milliseconds: 20), () async {
                              ^
```