### PR TITLE
fix: deprecated ui.window

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -15,7 +15,7 @@ class MyApp extends StatelessWidget {
       title: 'Flutter Demo',
       theme: ThemeData(
         textTheme: TextTheme(
-            headline6: TextStyle(
+            titleLarge: TextStyle(
           color: Colors.yellow,
           // fontSize: 50,
         )),
@@ -123,7 +123,7 @@ class _MyHomePageState extends State<MyHomePage> {
                         ),
                         Text(
                           "This is an invisible widget",
-                          style: Theme.of(context).textTheme.headline6,
+                          style: Theme.of(context).textTheme.titleLarge,
                         ),
                       ],
                     ));
@@ -152,10 +152,7 @@ class _MyHomePageState extends State<MyHomePage> {
         appBar: AppBar(
           title: Text("Captured widget screenshot"),
         ),
-        body: Center(
-            child: capturedImage != null
-                ? Image.memory(capturedImage)
-                : Container()),
+        body: Center(child: Image.memory(capturedImage)),
       ),
     );
   }

--- a/example/test/widget_test.dart
+++ b/example/test/widget_test.dart
@@ -8,7 +8,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:example/main.dart';
+import '../lib/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {

--- a/lib/screenshot.dart
+++ b/lib/screenshot.dart
@@ -64,8 +64,8 @@ class ScreenshotController {
   }
 
   Future<ui.Image?> captureAsUiImage(
-      {double? pixelRatio: 1,
-      Duration delay: const Duration(milliseconds: 20)}) {
+      {double? pixelRatio = 1,
+      Duration delay = const Duration(milliseconds: 20)}) {
     //Delay is required. See Issue https://github.com/flutter/flutter/issues/22308
     return new Future.delayed(delay, () async {
       try {
@@ -98,7 +98,7 @@ class ScreenshotController {
   ///
   Future<Uint8List> captureFromWidget(
     Widget widget, {
-    Duration delay: const Duration(seconds: 1),
+    Duration delay = const Duration(seconds: 1),
     double? pixelRatio,
     BuildContext? context,
     Size? targetSize,
@@ -115,9 +115,10 @@ class ScreenshotController {
     return byteData!.buffer.asUint8List();
   }
 
+  /// If you are building a desktop/web application that supports multiple view. Consider passing the [context] so that flutter know which view to capture.
   static Future<ui.Image> widgetToUiImage(
     Widget widget, {
-    Duration delay: const Duration(seconds: 1),
+    Duration delay = const Duration(seconds: 1),
     double? pixelRatio,
     BuildContext? context,
     Size? targetSize,
@@ -147,17 +148,20 @@ class ScreenshotController {
     }
 
     final RenderRepaintBoundary repaintBoundary = RenderRepaintBoundary();
-
-    Size logicalSize = targetSize ??
-        ui.window.physicalSize / ui.window.devicePixelRatio; // Adapted
-    Size imageSize = targetSize ?? ui.window.physicalSize; // Adapted
+    final platformDispatcher = WidgetsBinding.instance.platformDispatcher;
+    final fallBackView = platformDispatcher.views.first;
+    final view =
+        context == null ? fallBackView : View.maybeOf(context) ?? fallBackView;
+    Size logicalSize =
+        targetSize ?? view.physicalSize / view.devicePixelRatio; // Adapted
+    Size imageSize = targetSize ?? view.physicalSize; // Adapted
 
     assert(logicalSize.aspectRatio.toStringAsPrecision(5) ==
         imageSize.aspectRatio
             .toStringAsPrecision(5)); // Adapted (toPrecision was not available)
 
     final RenderView renderView = RenderView(
-      window: ui.window,
+      view: view,
       child: RenderPositionedBox(
           alignment: Alignment.center, child: repaintBoundary),
       configuration: ViewConfiguration(
@@ -242,17 +246,14 @@ class ScreenshotController {
       ///
       ///retry untill capture is successfull
       ///
-
     } while (isDirty && retryCounter >= 0);
     try {
-
-      /// Dispose All widgets 
+      /// Dispose All widgets
       rootElement.visitChildren((Element element) {
         rootElement.deactivateChild(element);
       });
       buildOwner.finalizeTree();
     } catch (e) {}
-
 
     return image; // Adapted to directly return the image and not the Uint8List
   }


### PR DESCRIPTION
Same as #132

Fixes #127

Flutter is adding support for multiple views [see](https://docs.flutter.dev/release/breaking-changes/window-singleton). This package have reference to deprecating code in the future.