### PR TITLE
Replace ui.window with View.of(context) for Dart 3.0 & Flutter 3.10

### DIFF
--- a/lib/screenshot.dart
+++ b/lib/screenshot.dart
@@ -148,16 +148,17 @@ class ScreenshotController {
 
     final RenderRepaintBoundary repaintBoundary = RenderRepaintBoundary();
 
+    ui.FlutterView flutterView = View.of(context!);
     Size logicalSize = targetSize ??
-        ui.window.physicalSize / ui.window.devicePixelRatio; // Adapted
-    Size imageSize = targetSize ?? ui.window.physicalSize; // Adapted
+        flutterView.physicalSize / flutterView.devicePixelRatio; // Adapted
+    Size imageSize = targetSize ?? flutterView.physicalSize; // Adapted
 
     assert(logicalSize.aspectRatio.toStringAsPrecision(5) ==
         imageSize.aspectRatio
             .toStringAsPrecision(5)); // Adapted (toPrecision was not available)
 
     final RenderView renderView = RenderView(
-      window: ui.window,
+      view: flutterView,
       child: RenderPositionedBox(
           alignment: Alignment.center, child: repaintBoundary),
       configuration: ViewConfiguration(


### PR DESCRIPTION
ui.window has been deprecated to prepare for the upcoming multi-window support.