### PR TITLE
Update ViewConfiguration parameters for Flutter 3.18.0 + api change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [2.1.1] - 06/12/2023
-* Fixed widgetToUiImage() to use ViewConstraints object in ViewConfiguration() constructor call instead of Size (required due to flutter api change)
+* Fixed widgetToUiImage() to use new ViewConfiguration() constructor parameters of BoxConstraints instead of Size (required due to flutter api change)
 ## [2.1.0] - 13/05/2023
 * New Functions: `captureFromLongWidget` and `longWidgetToUiImage`. Calculates widgets size and captures whole widget at once.
 * BREAKING CHANGE: add minimum flutter version constraint. so if your project is below flutter 3.10, Please consider using version 1.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## [2.1.1] - 06/12/2023
-* Fixed widgetToUiImage() to use ViewConstraints object in ViewConfiguration() constructor call instead of size
+* Fixed widgetToUiImage() to use ViewConstraints object in ViewConfiguration() constructor call instead of Size (required due to flutter api change)
 ## [2.1.0] - 13/05/2023
 * New Functions: `captureFromLongWidget` and `longWidgetToUiImage`. Calculates widgets size and captures whole widget at once.
 * BREAKING CHANGE: add minimum flutter version constraint. so if your project is below flutter 3.10, Please consider using version 1.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## [2.1.1] - 06/12/2023
+* Fixed widgetToUiImage() to use ViewConstraints object in ViewConfiguration() constructor call instead of size
 ## [2.1.0] - 13/05/2023
 * New Functions: `captureFromLongWidget` and `longWidgetToUiImage`. Calculates widgets size and captures whole widget at once.
 * BREAKING CHANGE: add minimum flutter version constraint. so if your project is below flutter 3.10, Please consider using version 1.3.0

--- a/lib/screenshot.dart
+++ b/lib/screenshot.dart
@@ -155,6 +155,11 @@ class ScreenshotController {
     Size logicalSize =
         targetSize ?? view.physicalSize / view.devicePixelRatio; // Adapted
     Size imageSize = targetSize ?? view.physicalSize; // Adapted
+    final viewConfig = ViewConfiguration(
+      physicalConstraints: BoxConstraints.tight(imageSize),
+      logicalConstraints: BoxConstraints.tight(logicalSize),
+      devicePixelRatio: pixelRatio ?? 1.0,
+    );
 
     assert(logicalSize.aspectRatio.toStringAsPrecision(5) ==
         imageSize.aspectRatio
@@ -164,10 +169,7 @@ class ScreenshotController {
       view: view,
       child: RenderPositionedBox(
           alignment: Alignment.center, child: repaintBoundary),
-      configuration: ViewConfiguration(
-        constraints:  ui.ViewConstraints(maxWidth: logicalSize.width, maxHeight: logicalSize.height),
-        devicePixelRatio: pixelRatio ?? 1.0,
-      ),
+      configuration: viewConfig,
     );
 
     final PipelineOwner pipelineOwner = PipelineOwner();

--- a/lib/screenshot.dart
+++ b/lib/screenshot.dart
@@ -165,7 +165,7 @@ class ScreenshotController {
       child: RenderPositionedBox(
           alignment: Alignment.center, child: repaintBoundary),
       configuration: ViewConfiguration(
-        size: logicalSize,
+        constraints:  ui.ViewConstraints(maxWidth: logicalSize.width, maxHeight: logicalSize.height),
         devicePixelRatio: pixelRatio ?? 1.0,
       ),
     );

--- a/lib/screenshot.dart
+++ b/lib/screenshot.dart
@@ -155,11 +155,6 @@ class ScreenshotController {
     Size logicalSize =
         targetSize ?? view.physicalSize / view.devicePixelRatio; // Adapted
     Size imageSize = targetSize ?? view.physicalSize; // Adapted
-    final viewConfig = ViewConfiguration(
-      physicalConstraints: BoxConstraints.tight(imageSize),
-      logicalConstraints: BoxConstraints.tight(logicalSize),
-      devicePixelRatio: pixelRatio ?? 1.0,
-    );
 
     assert(logicalSize.aspectRatio.toStringAsPrecision(5) ==
         imageSize.aspectRatio
@@ -169,7 +164,11 @@ class ScreenshotController {
       view: view,
       child: RenderPositionedBox(
           alignment: Alignment.center, child: repaintBoundary),
-      configuration: viewConfig,
+      configuration: ViewConfiguration(
+                        physicalConstraints: BoxConstraints.tight(imageSize),
+                        logicalConstraints: BoxConstraints.tight(logicalSize),
+                        devicePixelRatio: pixelRatio ?? 1.0,
+                      ),
     );
 
     final PipelineOwner pipelineOwner = PipelineOwner();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: screenshot
 description: Flutter Screenshot Package (Runtime). Capture any Widget as an image.
-version: 2.1.0
+version: 2.1.1
 homepage: https://github.com/SachinGanesh/screenshot
 
 environment:


### PR DESCRIPTION
This PR makes the required API changes to the ` ViewConfiguration()` constructor call in `widgetToUiImage()`.

`ViewConfiguration` now takes 
     `constraints:  ui.ViewConstraints(maxWidth: logicalSize.width, maxHeight: logicalSize.height),`
instead of 
     `size: logicalSize,`

